### PR TITLE
Add menu bar clipboard history

### DIFF
--- a/CmdC/ClipboardManager.swift
+++ b/CmdC/ClipboardManager.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import AppKit
+
+struct ClipboardItem: Identifiable {
+    let id = UUID()
+    let item: NSPasteboardItem
+    let display: String
+}
+
+class ClipboardManager: ObservableObject {
+    @Published var items: [ClipboardItem] = []
+    private var changeCount: Int = NSPasteboard.general.changeCount
+    private var timer: Timer?
+
+    init() {
+        startMonitoring()
+    }
+
+    private func startMonitoring() {
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            self.checkForChanges()
+        }
+    }
+
+    private func checkForChanges() {
+        let pb = NSPasteboard.general
+        guard pb.changeCount != changeCount else { return }
+        changeCount = pb.changeCount
+        if let newItem = pb.pasteboardItems?.first {
+            var display = "Unknown"
+            if let str = newItem.string(forType: .string) {
+                display = String(str.prefix(40))
+            } else if newItem.types.contains(.fileURL) {
+                display = "File URL"
+            } else if newItem.types.contains(.png) || newItem.types.contains(.tiff) {
+                display = "Image"
+            } else if let type = newItem.types.first {
+                display = type.rawValue
+            }
+            let item = ClipboardItem(item: newItem, display: display)
+            items.insert(item, at: 0)
+            if items.count > 10 {
+                items.removeLast()
+            }
+        }
+    }
+
+    func copy(_ item: ClipboardItem) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.writeObjects([item.item])
+    }
+
+    func clear() {
+        items.removeAll()
+        NSPasteboard.general.clearContents()
+    }
+}

--- a/CmdC/CmdCApp.swift
+++ b/CmdC/CmdCApp.swift
@@ -1,17 +1,20 @@
-//
-//  CmdCApp.swift
-//  CmdC
-//
-//  Created by Abid Aboobaker on 02/11/24.
-//
-
 import SwiftUI
+import AppKit
 
 @main
 struct CmdCApp: App {
+    @StateObject private var manager = ClipboardManager()
+
     var body: some Scene {
-        WindowGroup {
-            ContentView()
+        MenuBarExtra("CmdC", systemImage: "doc.on.clipboard") {
+            ForEach(manager.items) { item in
+                Button(item.display) {
+                    manager.copy(item)
+                }
+            }
+            Divider()
+            Button("Clear History") { manager.clear() }
+            Button("Quit") { NSApplication.shared.terminate(nil) }
         }
     }
 }

--- a/Info.plist
+++ b/Info.plist
@@ -20,5 +20,7 @@
     <string>1</string>
     <key>LSMinimumSystemVersion</key>
     <string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+    <key>LSUIElement</key>
+    <string>1</string>
 </dict>
 </plist>

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,7 @@ A simple Safari extension that allows you to quickly copy the current page URL u
 - Copy current page URL with Command+Shift+C keyboard shortcut
 - Shows notification when URL is copied
 - Works on all websites
+- **New:** macOS menu bar clipboard manager shows last 10 copied items and lets you copy them again or clear the history
 
 ## Technical Details
 
@@ -29,3 +30,4 @@ Default keyboard shortcut: Command+Shift+C
 1. Install the extension
 2. Use Command+Shift+C to copy the current page URL
 3. URL will be copied to clipboard with a confirmation notification
+4. Access clipboard history from the CmdC menu bar icon


### PR DESCRIPTION
## Summary
- implement `ClipboardManager` to monitor the system clipboard
- show the last 10 clipboard items in a `MenuBarExtra`
- allow copying items and clearing history
- hide the dock icon with `LSUIElement`
- document the new clipboard manager feature

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_683fe1022584832389c4c48bfe85065c