### PR TITLE
Add Swift Package manifest

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,39 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "CmdC",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .executable(name: "CmdC", targets: ["CmdC"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apple/swift-testing.git", from: "0.5.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "CmdC",
+            path: "CmdC",
+            resources: [
+                .process("Assets.xcassets"),
+                .process("Preview Content")
+            ]
+        ),
+        .testTarget(
+            name: "CmdCTests",
+            dependencies: [
+                "CmdC",
+                .product(name: "Testing", package: "swift-testing")
+            ],
+            path: "CmdCTests"
+        ),
+        .testTarget(
+            name: "CmdCUITests",
+            dependencies: ["CmdC"],
+            path: "CmdCUITests"
+        )
+    ]
+)

--- a/Readme.md
+++ b/Readme.md
@@ -2,6 +2,7 @@
 
 A simple Safari extension that allows you to quickly copy the current page URL using a keyboard shortcut. I was using Arc for last few months and got addicted to the Command Shift C for copying url, so I build the same on Safari while I moved back.
 
+This repository includes a Swift Package manifest so the app can be built using Swift Package Manager.
 ## Features
 
 - Copy current page URL with Command+Shift+C keyboard shortcut
@@ -29,3 +30,6 @@ Default keyboard shortcut: Command+Shift+C
 1. Install the extension
 2. Use Command+Shift+C to copy the current page URL
 3. URL will be copied to clipboard with a confirmation notification
+
+## Building with Swift Package Manager
+If you prefer to use Swift Package Manager, simply run `swift build` in the repository root. The package manifest describes the macOS app target and test suites.


### PR DESCRIPTION
## Summary
- add `Package.swift` for building CmdC with Swift Package Manager
- mention new manifest and SPM build instructions in `Readme.md`

## Testing
- `swift build` *(fails: unable to access 'https://github.com/apple/swift-testing.git')*
- `swift test` *(fails: unable to access 'https://github.com/apple/swift-testing.git')*

------
https://chatgpt.com/codex/tasks/task_e_68404d2b45448323af62d9bddab17a42